### PR TITLE
Fix HintManager error

### DIFF
--- a/power-libperfmgr/aidl/PowerSessionManager.cpp
+++ b/power-libperfmgr/aidl/PowerSessionManager.cpp
@@ -81,6 +81,7 @@ static void set_uclamp_min(int tid, int min) {
 }
 }  // namespace
 
+// TODO(jimmyshiu@): Deprecated. Remove once all powerhint.json up-to-date.
 void PowerSessionManager::updateHintMode(const std::string &mode, bool enabled) {
     ALOGV("PowerSessionManager::updateHintMode: mode: %s, enabled: %d", mode.c_str(), enabled);
     if (enabled && mode.compare(0, 8, "REFRESH_") == 0) {
@@ -92,8 +93,8 @@ void PowerSessionManager::updateHintMode(const std::string &mode, bool enabled) 
             mDisplayRefreshRate = 60;
         }
     }
-    if (HintManager::GetInstance()->GetAdpfProfile()) {
-        HintManager::GetInstance()->SetAdpfProfile(mode);
+    if (HintManager::GetInstance()->GetAdpfProfileFromDoHint()) {
+        HintManager::GetInstance()->SetAdpfProfileFromDoHint(mode);
     }
 }
 


### PR DESCRIPTION
```bash
FAILED: //hardware/lineage/interfaces/power-libperfmgr:android.hardware.power-service.lineage-libperfmgr clang++ aidl/PowerSessionManager.cpp
Outputs: out/soong/.intermediates/hardware/lineage/interfaces/power-libperfmgr/android.hardware.power-service.lineage-libperfmgr/android_vendor_arm64_armv8-2a-dotprod_cortex-a76/obj/hardware/lineage/interfaces/power-libperfmgr/aidl/PowerSessionManager.o
Error: exited with code: 1
Command: PWD=/proc/self/cwd prebuilts/clang/host/linux-x86/clang-r530567/bin/clang++ -c -D__ANDROID_VNDK__ -D__ANDROID_VENDOR__ -D__ANDROID_VENDOR_API__=202404  -Werror=implicit-function-declaration -D__BIONIC_DEPRECATED_PAGE_SIZE_MACRO -O2 -Wall -Wextra -Winit-self -Wpointer-arith -Wunguarded-availability -Werror=date-time -Werror=int-conversion -Werror=pragma-pack -Werror=pragma-pack-suspicious-include -Werror=sizeof-array-div -Werror=string-plus-int -Werror=unreachable-code-loop-increment -Wno-error=deprecated-declarations -Wno-c99-designator -Wno-gnu-folding-constant -Wno-inconsistent-missing-override -Wno-error=reorder-init-list -Wno-reorder-init-list -Wno-sign-compare -Wno-unused -DANDROID -DNDEBUG -UDEBUG -D__compiler_offsetof=__builtin_offsetof -D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__ -faddrsig -fdebug-default-version=5 -fcolor-diagnostics -ffp-contract=off -fno-exceptions -fno-strict-aliasing -fmessage-length=0 -gsimple-template-names -gz=zstd -no-canonical-prefixes -fdebug-prefix-map=/proc/self/cwd= -ftrivial-auto-var-init=zero -g -ffunction-sections -fdata-sections -fno-short-enums -funwind-tables -fstack-protector-strong -Wa,--noexecstack -D_FORTIFY_SOURCE=2 -Wstrict-aliasing=2 -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Werror=format-security -nostdlibinc -Wno-enum-compare -Wno-enum-compare-switch -Wno-null-pointer-arithmetic -Wno-null-dereference -Wno-pointer-compare -Wno-final-dtor-non-final-class -Wno-psabi -Wno-null-pointer-subtraction -Wno-string-concatenation -Wno-deprecated-non-prototype -Wno-unused -Wno-deprecated -Wno-error=format -march=armv8.2-a+dotprod -mcpu=cortex-a55 -target aarch64-linux-android35 -DANDROID_STRICT -fPIE -Wimplicit-fallthrough -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -Wno-gnu-include-next -fvisibility-inlines-hidden  -Ihardware/lineage/interfaces/power-libperfmgr -Iframeworks/native/libs/binder/ndk/include_cpp -Iframeworks/native/libs/binder/ndk/include_ndk -Iframeworks/native/libs/binder/ndk/include_platform -Isystem/core/libvendorsupport/include_llndk -Iout/soong/.intermediates/hardware/interfaces/power/aidl/android.hardware.power-V4-ndk-source/gen/include -Isystem/libbase/include -Iexternal/fmtlib/include -Isystem/core/libcutils/include_outside_system -Isystem/core/libprocessgroup/include -Isystem/core/libcutils/include -Isystem/logging/liblog/include_vndk -Ihardware/google/pixel/power-libperfmgr/libperfmgr/include -Isystem/core/libutils/include -Isystem/core/libsystem/include -Isystem/core/libutils/binder/include -Iout/soong/.intermediates/hardware/google/interfaces/power/pixel-power-ext-V1-ndk-source/gen/include -Iprebuilts/clang/host/linux-x86/clang-r530567/android_libc++/platform/aarch64/include/c++/v1 -Iprebuilts/clang/host/linux-x86/clang-r530567/include/c++/v1 -isystem bionic/libc/include -isystem bionic/libc/kernel/uapi/asm-arm64 -isystem bionic/libc/kernel/uapi -isystem bionic/libc/kernel/android/scsi -isystem bionic/libc/kernel/android/uapi -Werror -Wno-unused-variable -Wno-unused-parameter -DDO_NOT_CHECK_MANUAL_BINDER_INTERFACES -flto=thin -fsplit-lto-unit -std=gnu++20 -fno-rtti  -Werror=bool-operation -Werror=format-insufficient-args -Werror=implicit-int-float-conversion -Werror=int-in-bool-context -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -Werror=xor-used-as-pow -Wno-void-pointer-to-enum-cast -Wno-void-pointer-to-int-cast -Wno-pointer-to-int-cast -Werror=fortify-source -Wno-unused-variable -Wno-missing-field-initializers -Wno-packed-non-pod -Werror=address-of-temporary -Werror=incompatible-function-pointer-types -Werror=null-dereference -Werror=return-type -Wno-tautological-constant-compare -Wno-tautological-type-limit-compare -Wno-implicit-int-float-conversion -Wno-tautological-overlap-compare -Wno-deprecated-copy -Wno-range-loop-construct -Wno-zero-as-null-pointer-constant -Wno-deprecated-anon-enum-enum-conversion -Wno-deprecated-enum-enum-conversion -Wno-error=pessimizing-move -Wno-non-c-typedef-for-linkage -Wno-align-mismatch -Wno-error=unused-but-set-variable -Wno-error=unused-but-set-parameter -Wno-error=deprecated-builtins -Wno-error=deprecated -Wno-deprecated-dynamic-exception-spec -Wno-error=enum-constexpr-conversion -Wno-error=invalid-offsetof -Wno-error=thread-safety-reference-return -Wno-vla-cxx-extension  -fcommon -Wno-format-insufficient-args -Wno-misleading-indentation -Wno-bitwise-instead-of-logical -Wno-unused -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unqualified-std-cast-call -Wno-array-parameter -Wno-gnu-offsetof-extensions -Wno-pessimizing-move -Wno-fortify-source -MD -MF out/soong/.intermediates/hardware/lineage/interfaces/power-libperfmgr/android.hardware.power-service.lineage-libperfmgr/android_vendor_arm64_armv8-2a-dotprod_cortex-a76/obj/hardware/lineage/interfaces/power-libperfmgr/aidl/PowerSessionManager.o.d -o out/soong/.intermediates/hardware/lineage/interfaces/power-libperfmgr/android.hardware.power-service.lineage-libperfmgr/android_vendor_arm64_armv8-2a-dotprod_cortex-a76/obj/hardware/lineage/interfaces/power-libperfmgr/aidl/PowerSessionManager.o hardware/lineage/interfaces/power-libperfmgr/aidl/PowerSessionManager.cpp
Output:
[1mhardware/lineage/interfaces/power-libperfmgr/aidl/PowerSessionManager.cpp:96:56: [0m[0;1;31merror: [0m[1mtoo few arguments to function call, expected 2, have 1[0m
   96 |         HintManager::GetInstance()->SetAdpfProfile(mode);[0m
      | [0;1;32m        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ^
[0m[1mhardware/google/pixel/power-libperfmgr/libperfmgr/include/perfmgr/HintManager.h:132:10: [0m[0;1;36mnote: [0m'SetAdpfProfile' declared here[0m
  132 |     [0;34mbool[0m SetAdpfProfile([0;34mconst[0m std::string &tag, [0;34mconst[0m std::string &profile);[0m
      | [0;1;32m         ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[0m1 error generated.
```
PR fix this error
or need sync with lineage-22.1 branch(or even delete this repo and use lineage_interfaces from LineageOS)